### PR TITLE
Improve deployment scripts for new VPS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Run automated tests:
 scripts/run_tests.sh
 ```
 
+Install Fluent Bit on the central VPS:
+```bash
+scripts/install_fluentbit.sh
+```
+
 Deploy configuration to all nodes:
 ```bash
 scripts/deploy.sh
@@ -34,7 +39,7 @@ Run a one-shot health check and rotate the combined log if it grows too large:
 scripts/monitor.py
 ```
 
-Check health of each node and the core container:
+Check health of each node and the core VPS:
 ```bash
 scripts/healthcheck.sh
 ```

--- a/filebeat/corrected_filebeat.yml
+++ b/filebeat/corrected_filebeat.yml
@@ -4,18 +4,14 @@ filebeat.inputs:
     paths:
       - /var/log/test.log
 
-# WORKING: Using Elasticsearch output (NOT tcp!)
-output.elasticsearch:
-  hosts: ["104.255.9.187:5044"]
-  protocol: "http"
-  path: "/"
-  index: ""
-  bulk_max_size: 1
-  username: ""
-  password: ""
+# Forward logs to central Fluent Bit instance via HTTP
+output.http:
+  hosts: ["145.223.73.4:5044"]
   ssl.enabled: false
-  max_retries: 0
+  max_retries: 3
   timeout: 30
+  headers:
+    Content-Type: application/json
 
 logging.level: error
 logging.to_files: false

--- a/fluent-bit/fluent-bit.conf
+++ b/fluent-bit/fluent-bit.conf
@@ -10,6 +10,12 @@
     Port   5044
     Format none
 
+[INPUT]
+    Name   tail
+    Path   /var/log/syslog
+    Tag    local
+    Refresh_Interval 5
+
 [FILTER]
     Name   parser
     Match  *
@@ -24,4 +30,4 @@
 [OUTPUT]
     Name   file
     Match  *
-    Path   /tmp/fb_combined.log
+    Path   /tmp/vps_combined.log

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(srv803495 srv832635 srv832638 srv832660 srv832662)
-CORE_VPS=104.255.9.187
-CONTAINER=d82c6a1a4730
+NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
+CORE_VPS=145.223.73.4
 CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/fluent-bit"
 BACKUP_DIR=/var/backups/fluent-bit
 
@@ -20,7 +19,7 @@ for NODE in "${NODES[@]}"; do
   log "Deployment complete on ${NODE}"
 done
 
-log "Deploying configuration to core container"
+log "Deploying configuration to core VPS"
 scp "${CONFIG_DIR}/fluent-bit.conf" "${CORE_VPS}:/tmp/fluent-bit.conf"
-ssh "${CORE_VPS}" "docker cp /tmp/fluent-bit.conf ${CONTAINER}:/fluent-bit/etc/fluent-bit.conf && docker exec ${CONTAINER} /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf"
+ssh "${CORE_VPS}" "sudo mv /tmp/fluent-bit.conf /etc/fluent-bit/fluent-bit.conf && sudo systemctl restart fluent-bit"
 log "Deployment finished"

--- a/scripts/deploy_filebeat.py
+++ b/scripts/deploy_filebeat.py
@@ -11,14 +11,12 @@ FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"
 
 NODES = [
-    "145.223.73.4",
     "31.97.13.92",
     "31.97.13.95",
     "31.97.13.100",
     "31.97.13.102",
 ]
-CORE_VPS = "104.255.9.187"
-CONTAINER = "d82c6a1a4730"
+CORE_VPS = "145.223.73.4"
 
 
 def log(msg: str):
@@ -75,12 +73,13 @@ def deploy_filebeat(node: str):
 
 def configure_fluentbit():
     log("Configuring Fluent Bit on core VPS")
-    backup_cmd = "cp /fluent-bit/etc/fluent-bit.conf /fluent-bit/etc/fluent-bit.conf.bak.$(date +%s)"
+    backup_cmd = "cp /etc/fluent-bit/fluent-bit.conf /etc/fluent-bit/fluent-bit.conf.bak.$(date +%s) || true"
     ssh_cmd(CORE_VPS, backup_cmd)
     scp_file(CORE_VPS, FLUENT_BIT_CONFIG, "/tmp/fluent-bit.conf")
-    ssh_cmd(CORE_VPS, f"docker cp /tmp/fluent-bit.conf {CONTAINER}:/fluent-bit/etc/fluent-bit.conf")
-    ssh_cmd(CORE_VPS, f"docker exec {CONTAINER} pkill -f fluent-bit || true")
-    ssh_cmd(CORE_VPS, f"docker exec -d {CONTAINER} /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf")
+    ssh_cmd(CORE_VPS, "mv /tmp/fluent-bit.conf /etc/fluent-bit/fluent-bit.conf")
+    ssh_cmd(CORE_VPS, "systemctl daemon-reload")
+    ssh_cmd(CORE_VPS, "systemctl enable fluent-bit")
+    ssh_cmd(CORE_VPS, "systemctl restart fluent-bit")
     log("Fluent Bit configuration updated")
 
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(srv803495 srv832635 srv832638 srv832660 srv832662)
-CORE_VPS=104.255.9.187
-CONTAINER=d82c6a1a4730
-PORT=8000
+NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
+CORE_VPS=145.223.73.4
+PORT=5044
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
 
 for NODE in "${NODES[@]}"; do
-  if nc -z "$NODE" "$PORT"; then
-    log "${NODE} Fluent Bit port ${PORT} reachable"
+  if ssh "$NODE" "systemctl is-active filebeat >/dev/null"; then
+    log "${NODE} filebeat active"
   else
-    log "ERROR: ${NODE} Fluent Bit port ${PORT} unreachable"
+    log "ERROR: ${NODE} filebeat inactive"
   fi
- done
+done
 
-log "Checking container health"
-ssh "$CORE_VPS" "docker exec ${CONTAINER} curl -sf http://localhost:${PORT}/health" && log "Container healthy" || log "ERROR: Container health check failed"
+log "Checking Fluent Bit port on core VPS"
+if nc -z "$CORE_VPS" "$PORT"; then
+  log "Core VPS port ${PORT} reachable"
+else
+  log "ERROR: Core VPS port ${PORT} unreachable"
+fi

--- a/scripts/install_fluentbit.sh
+++ b/scripts/install_fluentbit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+if command -v fluent-bit >/dev/null 2>&1; then
+  log "Fluent Bit already installed"
+  exit 0
+fi
+
+log "Adding Fluent Bit repository (Ubuntu 24.04 compatibility)"
+if [ ! -f /usr/share/keyrings/fluentbit-keyring.gpg ]; then
+  curl -fsSL https://packages.fluentbit.io/fluentbit.key | sudo gpg --dearmor -o /usr/share/keyrings/fluentbit-keyring.gpg
+fi
+
+echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/noble noble main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list >/dev/null
+sudo apt-get update
+
+if ! sudo apt-get install -y fluent-bit; then
+  log "apt install failed, falling back to snap"
+  sudo snap install fluent-bit --classic
+fi
+
+sudo systemctl enable fluent-bit
+sudo systemctl restart fluent-bit
+log "Fluent Bit installation complete"

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -9,14 +9,13 @@ SSH_USER = os.getenv("SSH_USER", "root")
 SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
 
 NODES = [
-    "145.223.73.4",
     "31.97.13.92",
     "31.97.13.95",
     "31.97.13.100",
     "31.97.13.102",
 ]
-CORE_VPS = "104.255.9.187"
-LOG_PATH = "/tmp/fb_combined.log"
+CORE_VPS = "145.223.73.4"
+LOG_PATH = "/tmp/vps_combined.log"
 THRESHOLD = 5_000_000  # rotate log above 5MB
 
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(srv803495 srv832635 srv832638 srv832660 srv832662)
-CORE_VPS=104.255.9.187
-CONTAINER=d82c6a1a4730
+NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
+CORE_VPS=145.223.73.4
 BACKUP_DIR=/var/backups/fluent-bit
 
 log() {
@@ -20,6 +19,6 @@ for NODE in "${NODES[@]}"; do
   log "Rollback completed on ${NODE}"
 done
 
-log "Rolling back configuration on core container"
-ssh "$CORE_VPS" "docker cp ${CONTAINER}:${BACKUP_DIR}/fluent-bit.conf /tmp/fluent-bit.conf && docker exec ${CONTAINER} /fluent-bit/bin/fluent-bit -c /tmp/fluent-bit.conf"
+log "Rolling back configuration on core VPS"
+ssh "$CORE_VPS" "LATEST=\$(ls -t ${BACKUP_DIR}/fluent-bit.conf.* 2>/dev/null | head -n 1); if [ -n \"$LATEST\" ]; then sudo cp \"$LATEST\" /etc/fluent-bit/fluent-bit.conf && sudo systemctl restart fluent-bit; fi"
 log "Rollback finished"


### PR DESCRIPTION
## Summary
- update Filebeat to use HTTP output
- add central log collection to Fluent Bit and write to `/tmp/vps_combined.log`
- add installer for Fluent Bit on Ubuntu 25.04
- adjust deployment scripts to use new central VPS IP and no Docker
- update monitoring and healthcheck scripts
- document new installation step

## Testing
- `./scripts/run_tests.sh`