### PR TITLE
Add reverse SSH tunnel automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ Run an end-to-end test to confirm log forwarding:
 ```bash
 scripts/e2e_test.py
 ```
+
+## Reverse SSH tunnel setup
+
+To aggregate logs from remote VPS nodes using reverse SSH tunnels:
+
+1. On the RunPod container, start the tunnel manager which listens on
+   ports 5045-5049 and aggregates all logs to `/tmp/vps_combined.log`:
+
+```bash
+scripts/runpod_tunnel_manager.sh
+```
+
+2. On each VPS node, establish a persistent tunnel using `autossh`.
+   Specify the remote port assigned to the node when invoking the
+   setup script. Example for port 5045:
+
+```bash
+scripts/vps_tunnel_setup.sh 5045
+```
+
+Filebeat on the VPS should be configured with
+`filebeat/filebeat_tunnel.yml` so that logs are sent through the local
+port `5044` into the SSH tunnel.

--- a/filebeat/filebeat_tunnel.yml
+++ b/filebeat/filebeat_tunnel.yml
@@ -1,0 +1,24 @@
+filebeat.inputs:
+  - type: log
+    enabled: true
+    paths:
+      - /var/log/syslog
+
+# Send to local tunnel which forwards to RunPod
+output.http:
+  hosts: ["localhost:5044"]
+  ssl.enabled: false
+  max_retries: 3
+  timeout: 30
+  compression_level: 0
+
+# Use memory queue to avoid spool corruption/restarts
+queue.mem:
+  events: 4096
+  flush.min_events: 512
+  flush.timeout: 5s
+
+logging.level: error
+logging.to_files: false
+path.data: /var/lib/filebeat
+path.logs: /var/log/filebeat

--- a/scripts/runpod_tunnel_manager.sh
+++ b/scripts/runpod_tunnel_manager.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# runpod_tunnel_manager.sh - Accepts reverse SSH tunnels and aggregates logs
+#
+# This script runs on the RunPod container. It starts Fluent Bit to
+# collect logs on port 5044 and forwards ports 5045-5049 to this
+# internal collector. Each VPS establishes an SSH tunnel to one of
+# these ports. Logs from all VPS nodes are combined into a single
+# /tmp/vps_combined.log file.
+
+set -euo pipefail
+
+# Ports assigned to incoming tunnels
+TUNNEL_PORTS=(5045 5046 5047 5048 5049)
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+check_dependency() {
+  command -v "$1" >/dev/null 2>&1 || { echo "$1 is required" >&2; exit 1; }
+}
+
+main() {
+  check_dependency fluent-bit
+  check_dependency socat
+
+  log "Starting Fluent Bit aggregator"
+  fluent-bit -c fluent-bit/fluent-bit.conf &
+  FLUENT_PID=$!
+
+  log "Forwarding tunnel ports to local collector"
+  for port in "${TUNNEL_PORTS[@]}"; do
+    socat TCP-LISTEN:"$port",reuseaddr,fork TCP:localhost:5044 &
+  done
+
+  trap 'log "Stopping"; kill $FLUENT_PID; pkill -P $$ socat' INT TERM
+  wait
+}
+
+main "$@"

--- a/scripts/vps_tunnel_setup.sh
+++ b/scripts/vps_tunnel_setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# vps_tunnel_setup.sh - Create a persistent SSH tunnel from a VPS node to RunPod
+#
+# Usage: vps_tunnel_setup.sh <remote_port>
+# Each VPS is assigned a unique remote_port:
+#   145.223.73.4 -> 5045
+#   31.97.13.92  -> 5046
+#   31.97.13.95  -> 5047
+#   31.97.13.100 -> 5048
+#   31.97.13.102 -> 5049
+#
+# The script configures autossh to expose local Filebeat (localhost:5044)
+# to RunPod on the given remote port. autossh automatically restarts the
+# tunnel if the connection drops.
+
+set -euo pipefail
+
+RUNPOD_HOST="root@d82c6a1a4730"
+RUNPOD_PORT=22
+SSH_PASSWORD="SDAasdsa23..dsS"
+LOCAL_PORT=5044
+
+usage() {
+  echo "Usage: $0 <remote_port>" >&2
+  exit 1
+}
+
+check_dependency() {
+  command -v "$1" >/dev/null 2>&1 || { echo "$1 is required" >&2; exit 1; }
+}
+
+if [ $# -ne 1 ]; then
+  usage
+fi
+REMOTE_PORT=$1
+
+main() {
+  check_dependency autossh
+  check_dependency sshpass
+
+  export AUTOSSH_GATETIME=0
+  export AUTOSSH_POLL=30
+
+  sshpass -p "$SSH_PASSWORD" \
+    autossh -M 0 -N \
+    -o "ServerAliveInterval=60" \
+    -o "ServerAliveCountMax=3" \
+    -o "ExitOnForwardFailure=yes" \
+    -o "StrictHostKeyChecking=no" \
+    -L "${LOCAL_PORT}:localhost:${REMOTE_PORT}" \
+    -p "$RUNPOD_PORT" "$RUNPOD_HOST"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- automate reverse SSH tunnels for unreachable VPS nodes
- add script to manage tunnels on RunPod side
- add script for VPS nodes to establish persistent tunnels
- provide Filebeat config tuned for tunnels
- document usage in README

## Testing
- `scripts/run_tests.sh`