### PR TITLE
Add minimal Trinity AI web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+node_modules/
+frontend/.next/
+.env

--- a/README.md
+++ b/README.md
@@ -104,3 +104,25 @@ sudo scripts/enable_external_access.sh
 ```
 
 This script enables ports 80 and 443 via `ufw` and `iptables`, ensures Nginx listens on all interfaces, and reloads the server.
+
+## Trinity AI Web Interface
+
+A minimal web interface is provided as a starting point for the future
+"ultimate" Trinity AI UI. The backend API is implemented with Flask in
+`app.py` and exposes a `/api/chat` endpoint. A Next.js 14 frontend lives in
+`frontend/`.
+
+### Running locally
+
+1. Start the Flask API:
+   ```bash
+   python3 app.py
+   ```
+2. In the `frontend/` directory install dependencies and run the dev server:
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+The frontend will send chat prompts to `http://localhost:8000/api/chat` and
+display the result.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+"""Flask server exposing the Trinity AI interface."""
+
+from __future__ import annotations
+
+from flask import Flask, request, jsonify
+
+from trinity_ai import TrinityAI
+
+app = Flask(__name__)
+trinity = TrinityAI()
+
+
+@app.route("/api/chat", methods=["POST"])
+def chat() -> tuple:
+    """Return a chat completion from the selected model."""
+    data = request.get_json(force=True)
+    prompt = data.get("prompt")
+    model = data.get("model", "openai")
+    if not prompt:
+        return jsonify({"error": "prompt required"}), 400
+    try:
+        response = trinity.chat(prompt, model=model)
+    except Exception as exc:  # pragma: no cover - network failures
+        return jsonify({"error": str(exc)}), 500
+    return jsonify({"response": response})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(host="0.0.0.0", port=8000)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,18 @@
+# Trinity AI Frontend
+
+This directory contains a minimal Next.js 14 application written in TypeScript.
+It provides a basic chat interface that communicates with the Flask backend in
+`app.py`.
+
+## Development
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The app expects the Flask API to be running on `http://localhost:8000`.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Home() {
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+
+  async function sendPrompt() {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, model: 'openai' }),
+    });
+    const data = await res.json();
+    setResponse(data.response || data.error);
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Trinity AI Dashboard</h1>
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        className="w-full border p-2"
+        rows={4}
+      />
+      <button onClick={sendPrompt} className="mt-2 px-4 py-2 bg-blue-500 text-white">
+        Send
+      </button>
+      <pre className="mt-4 whitespace-pre-wrap">{response}</pre>
+    </main>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true },
+};
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "trinity-ui",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Flask server `app.py` exposing `/api/chat`
- add starter Next.js frontend under `frontend/`
- document how to run the new interface in README
- ignore node modules and temporary files

## Testing
- `scripts/run_tests.sh`