### PR TITLE
Fix Next.js build configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,3 +16,21 @@ It provides a basic chat interface that communicates with the Flask backend in
    ```
 
 The app expects the Flask API to be running on `http://localhost:8000`.
+
+## Production build
+
+Next.js can require a fair amount of memory when compiling. If the build
+process fails with an out-of-memory error, run the build with an increased
+memory limit:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=4096 npm run build
+```
+
+This sets the V8 heap to 4&nbsp;GB which prevents the Rust panic observed in
+resource constrained environments. After building, start the production server
+with:
+
+```bash
+npm run start
+```

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: { appDir: true },
+  // The `app` directory is stable in Next.js 14 so no experimental flag is
+  // required. Removing `experimental.appDir` avoids a config validation error
+  // during `next build`.
 };
+
 module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- remove deprecated experimental.appDir flag
- increase Next.js build memory in package.json
- document memory usage in the frontend README

## Testing
- `./scripts/run_tests.sh`