### PR TITLE
Add Gunicorn startup and requirements for Trinity API

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,15 @@ A minimal web interface is provided as a starting point for the future
 
 ### Running locally
 
-1. Start the Flask API:
+1. Install the Python dependencies:
    ```bash
-   python3 app.py
+   python3 -m pip install -r requirements.txt
    ```
-2. In the `frontend/` directory install dependencies and run the dev server:
+2. Start the production API using Gunicorn:
+   ```bash
+   scripts/start_trinity_server.sh
+   ```
+3. In the `frontend/` directory install dependencies and run the dev server:
    ```bash
    npm install
    npm run dev

--- a/app.py
+++ b/app.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from flask import Flask, request, jsonify
+from flask_cors import CORS
 
 from trinity_ai import TrinityAI
 
 app = Flask(__name__)
+CORS(app)
 trinity = TrinityAI()
 
 
@@ -23,6 +25,18 @@ def chat() -> tuple:
     except Exception as exc:  # pragma: no cover - network failures
         return jsonify({"error": str(exc)}), 500
     return jsonify({"response": response})
+
+
+@app.route("/api/status", methods=["GET"])
+def status() -> tuple:
+    """Simple status endpoint for health checks."""
+    return jsonify({"status": "ok"})
+
+
+@app.route("/health", methods=["GET"])
+def health() -> tuple:
+    """Compatibility health check endpoint."""
+    return jsonify({"status": "healthy"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==2.3.3
+Flask-CORS==4.0.0
+Gunicorn==21.2.0
+requests==2.31.0
+openai==1.82.0

--- a/scripts/start_trinity_server.sh
+++ b/scripts/start_trinity_server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launch the production Trinity AI API using Gunicorn.
+exec gunicorn --bind 0.0.0.0:8000 --workers 4 app:app


### PR DESCRIPTION
## Summary
- add `requirements.txt` with production dependencies
- expose CORS and health endpoints in `app.py`
- add `start_trinity_server.sh` helper for running Gunicorn
- update README with new startup instructions

## Testing
- `scripts/run_tests.sh`