### PR TITLE
Add minimal Pinarch login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,6 @@ A minimal web interface is provided as a starting point for the future
    ```
 
 The frontend will send chat prompts to `http://localhost:8000/api/chat` and
-display the result.
+display the result. The root path redirects to `/login`, which prompts for the
+`PINARCH_TOKEN` (default `DSFSfdss22$24@21--sdfsfsdf2442442`). After a valid
+login, the Trinity AI dashboard is available at `/dashboard`.

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from flask import Flask, request, jsonify
+import os
 from flask_cors import CORS
 
 from trinity_ai import TrinityAI
@@ -10,6 +11,7 @@ from trinity_ai import TrinityAI
 app = Flask(__name__)
 CORS(app)
 trinity = TrinityAI()
+PINARCH_TOKEN = os.getenv("PINARCH_TOKEN", "DSFSfdss22$24@21--sdfsfsdf2442442")
 
 
 @app.route("/api/chat", methods=["POST"])
@@ -25,6 +27,16 @@ def chat() -> tuple:
     except Exception as exc:  # pragma: no cover - network failures
         return jsonify({"error": str(exc)}), 500
     return jsonify({"response": response})
+
+
+@app.route("/api/login", methods=["POST"])
+def login() -> tuple:
+    """Authenticate using the Pinarch token."""
+    data = request.get_json(force=True)
+    token = data.get("token")
+    if token == PINARCH_TOKEN:
+        return jsonify({"success": True})
+    return jsonify({"success": False}), 401
 
 
 @app.route("/api/status", methods=["GET"])

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Home() {
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+
+  async function sendPrompt() {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, model: 'openai' }),
+    });
+    const data = await res.json();
+    setResponse(data.response || data.error);
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Trinity AI Dashboard</h1>
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        className="w-full border p-2"
+        rows={4}
+      />
+      <button onClick={sendPrompt} className="mt-2 px-4 py-2 bg-blue-500 text-white">
+        Send
+      </button>
+      <pre className="mt-4 whitespace-pre-wrap">{response}</pre>
+    </main>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Login() {
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  async function handleLogin() {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (res.ok) {
+      localStorage.setItem('pinarch_token', token);
+      router.push('/dashboard');
+    } else {
+      setError('Invalid token');
+    }
+  }
+
+  return (
+    <main className="p-4 flex flex-col items-center">
+      <h1 className="text-2xl font-bold mb-4">WELCOME PINARCH I'm JAMES</h1>
+      <input
+        type="password"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        className="border p-2 w-64"
+        placeholder="Enter token"
+      />
+      <button
+        onClick={handleLogin}
+        className="mt-2 px-4 py-2 bg-green-600 text-white"
+      >
+        Login
+      </button>
+      {error && <p className="mt-2 text-red-600">{error}</p>}
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,34 +1,6 @@
 'use client';
-
-import { useState } from 'react';
-
+import { redirect } from 'next/navigation';
 export default function Home() {
-  const [prompt, setPrompt] = useState('');
-  const [response, setResponse] = useState('');
-
-  async function sendPrompt() {
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt, model: 'openai' }),
-    });
-    const data = await res.json();
-    setResponse(data.response || data.error);
-  }
-
-  return (
-    <main className="p-4">
-      <h1 className="text-xl font-bold mb-4">Trinity AI Dashboard</h1>
-      <textarea
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
-        className="w-full border p-2"
-        rows={4}
-      />
-      <button onClick={sendPrompt} className="mt-2 px-4 py-2 bg-blue-500 text-white">
-        Send
-      </button>
-      <pre className="mt-4 whitespace-pre-wrap">{response}</pre>
-    </main>
-  );
+  redirect('/login');
+  return null;
 }


### PR DESCRIPTION
## Summary
- add simple `/api/login` endpoint to `app.py` and token constant
- create login page and dashboard in Next.js app
- redirect `/` to `/login` and document token login in README

## Testing
- `scripts/run_tests.sh`