### PR TITLE
Fix Next.js dev port and nginx config

### DIFF
--- a/etc/nginx/sites-available/trinity-nuclear
+++ b/etc/nginx/sites-available/trinity-nuclear
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    listen [::]:80;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name 325automations.com;
+
+    ssl_certificate     /etc/ssl/certs/placeholder.crt;
+    ssl_certificate_key /etc/ssl/private/placeholder.key;
+
+    location = / {
+        return 302 https://325automations.com/login;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/var/www/html/james/ultimate_ui/.env.local
+++ b/var/www/html/james/ultimate_ui/.env.local
@@ -1,0 +1,3 @@
+PORT=3000
+NEXT_PUBLIC_API_URL=https://325automations.com/api
+

--- a/var/www/html/james/ultimate_ui/package.json
+++ b/var/www/html/james/ultimate_ui/package.json
@@ -2,7 +2,7 @@
   "name": "trinity-ui",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 next build",
     "start": "next start"
   },


### PR DESCRIPTION
## Summary
- force Next.js dev server to use port 3000
- add environment settings for Next.js
- provide nginx config with proxy-only setup

## Testing
- `scripts/run_tests.sh`