### PR TITLE
Parameterize IP addresses via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Automation utilities for deployment and monitoring of Fluent Bit and Filebeat ac
 - `fluent-bit/` – Fluent Bit configuration files.
 - `filebeat/` – Filebeat configuration files.
 - `scripts/` – Automation scripts for deployment, rollback, health checks, testing and Filebeat setup.
+- `etc/addresses.env` – Example environment file providing IP addresses for all scripts.
 
 ## Usage
 
@@ -52,6 +53,27 @@ scripts/rollback.sh
 Run an end-to-end test to confirm log forwarding:
 ```bash
 scripts/e2e_test.py
+```
+
+## Configuring IP addresses
+
+All deployment and monitoring scripts read the list of VPS nodes and the
+address of the core aggregator from environment variables. An example
+file `etc/addresses.env` is provided. Source this file (or define the
+variables manually) before running any script:
+
+```bash
+source etc/addresses.env
+export NODES   # comma separated list of node IPs
+export CORE_VPS
+```
+
+Nginx and Fluent Bit configuration files use the variables `UI_HOST`,
+`UI_PORT`, `API_HOST`, `API_PORT` and `FLUENT_LISTEN_ADDR`. When deploying
+these configs you can apply `envsubst` to substitute the values:
+
+```bash
+envsubst < etc/nginx/sites-available/trinity-complete > /etc/nginx/sites-available/trinity-complete
 ```
 
 ## Reverse SSH tunnel setup

--- a/app.py
+++ b/app.py
@@ -68,4 +68,6 @@ def health() -> tuple:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    app.run(host="0.0.0.0", port=5001)
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "5001"))
+    app.run(host=host, port=port)

--- a/etc/addresses.env
+++ b/etc/addresses.env
@@ -1,0 +1,5 @@
+# Default IP addresses for deployment scripts
+# NODES is a comma-separated list of VPS hosts
+# CORE_VPS is the address of the central log aggregator
+NODES="31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102"
+CORE_VPS="145.223.73.4"

--- a/etc/nginx/sites-available/trinity-complete
+++ b/etc/nginx/sites-available/trinity-complete
@@ -15,13 +15,13 @@ server {
     }
 
     location / {
-        proxy_pass http://127.0.0.1:3000;
+        proxy_pass http://${UI_HOST}:${UI_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /api/ {
-        proxy_pass http://127.0.0.1:5001;
+        proxy_pass http://${API_HOST}:${API_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/etc/nginx/sites-available/trinity-nuclear
+++ b/etc/nginx/sites-available/trinity-nuclear
@@ -14,7 +14,7 @@ server {
     }
 
     location / {
-        proxy_pass http://127.0.0.1:3000;
+        proxy_pass http://${UI_HOST}:${UI_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
@@ -23,7 +23,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://127.0.0.1:5001;
+        proxy_pass http://${API_HOST}:${API_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/filebeat/corrected_filebeat.yml
+++ b/filebeat/corrected_filebeat.yml
@@ -6,7 +6,7 @@ filebeat.inputs:
 
 # Forward logs to central Fluent Bit instance via HTTP
 output.http:
-  hosts: ["145.223.73.4:5044"]
+  hosts: ["${CORE_VPS}:5044"]
   ssl.enabled: false
   max_retries: 3
   timeout: 30

--- a/fluent-bit/fluent-bit.conf
+++ b/fluent-bit/fluent-bit.conf
@@ -6,7 +6,7 @@
 
 [INPUT]
     Name   http
-    Listen 0.0.0.0
+    Listen ${FLUENT_LISTEN_ADDR}
     Port   5044
     Format none
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
-CORE_VPS=145.223.73.4
+CONFIG_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/etc/addresses.env"
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102}"
+: "${CORE_VPS:=145.223.73.4}"
+IFS=',' read -r -a NODES <<< "$NODES"
 CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/fluent-bit"
 BACKUP_DIR=/var/backups/fluent-bit
 

--- a/scripts/deploy_filebeat.py
+++ b/scripts/deploy_filebeat.py
@@ -10,13 +10,11 @@ SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
 FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_filebeat.yml"
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"
 
-NODES = [
-    "31.97.13.92",
-    "31.97.13.95",
-    "31.97.13.100",
-    "31.97.13.102",
-]
-CORE_VPS = "145.223.73.4"
+NODES = os.getenv(
+    "NODES",
+    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102",
+).split(",")
+CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
 
 
 def log(msg: str):

--- a/scripts/e2e_test.py
+++ b/scripts/e2e_test.py
@@ -9,14 +9,11 @@ from datetime import datetime
 SSH_USER = os.getenv("SSH_USER", "root")
 SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
 
-NODES = [
-    "145.223.73.4",
-    "31.97.13.92",
-    "31.97.13.95",
-    "31.97.13.100",
-    "31.97.13.102",
-]
-CORE_VPS = "104.255.9.187"
+NODES = os.getenv(
+    "NODES",
+    "145.223.73.4,31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102",
+).split(",")
+CORE_VPS = os.getenv("CORE_VPS", "104.255.9.187")
 LOG_PATH = "/tmp/fb_combined.log"
 
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
-CORE_VPS=145.223.73.4
+CONFIG_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/etc/addresses.env"
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102}"
+: "${CORE_VPS:=145.223.73.4}"
+IFS=',' read -r -a NODES <<< "$NODES"
 PORT=5044
 
 log() {

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -8,13 +8,11 @@ from pathlib import Path
 SSH_USER = os.getenv("SSH_USER", "root")
 SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
 
-NODES = [
-    "31.97.13.92",
-    "31.97.13.95",
-    "31.97.13.100",
-    "31.97.13.102",
-]
-CORE_VPS = "145.223.73.4"
+NODES = os.getenv(
+    "NODES",
+    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102",
+).split(",")
+CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
 LOG_PATH = "/tmp/vps_combined.log"
 THRESHOLD = 5_000_000  # rotate log above 5MB
 

--- a/scripts/recover_and_deploy.py
+++ b/scripts/recover_and_deploy.py
@@ -9,13 +9,11 @@ from pathlib import Path
 SSH_USER = os.getenv("SSH_USER", "root")
 SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
 
-NODES = [
-    "31.97.13.92",
-    "31.97.13.95",
-    "31.97.13.100",
-    "31.97.13.102",
-]
-CORE_VPS = "145.223.73.4"
+NODES = os.getenv(
+    "NODES",
+    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102",
+).split(",")
+CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
 
 FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_filebeat.yml"
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODES=(31.97.13.92 31.97.13.95 31.97.13.100 31.97.13.102)
-CORE_VPS=145.223.73.4
+CONFIG_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/etc/addresses.env"
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102}"
+: "${CORE_VPS:=145.223.73.4}"
+IFS=',' read -r -a NODES <<< "$NODES"
 BACKUP_DIR=/var/backups/fluent-bit
 
 log() {

--- a/scripts/start_trinity_server.sh
+++ b/scripts/start_trinity_server.sh
@@ -2,4 +2,6 @@
 set -euo pipefail
 
 # Launch the production Trinity AI API using Gunicorn.
-exec gunicorn --bind 0.0.0.0:5001 --workers 4 app:app
+BIND_ADDR="${BIND_ADDR:-0.0.0.0}" 
+BIND_PORT="${BIND_PORT:-5001}"
+exec gunicorn --bind "${BIND_ADDR}:${BIND_PORT}" --workers 4 app:app


### PR DESCRIPTION
## Summary
- move node addresses into `etc/addresses.env`
- read IP information from environment variables in scripts and configs
- add environment variable placeholders to nginx and fluent-bit configs
- update documentation on how to configure addresses

## Testing
- `scripts/run_tests.sh`