### PR TITLE
Use env vars for tokens/passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Automation utilities for deployment and monitoring of Fluent Bit and Filebeat across multiple nodes.
 
+## Required Environment Variables
+
+Before running the utilities or the web application, set the following environment variables:
+
+- `SSH_PASSWORD` – password used by the deployment and monitoring scripts when connecting to the VPS nodes.
+- `PINARCH_TOKEN` – secret token checked by `app.py` when clients authenticate via `/api/login`.
+
+Example:
+
+```bash
+export SSH_PASSWORD="<your_ssh_password>"
+export PINARCH_TOKEN="<your_pinarch_token>"
+```
+
 ## Directory overview
 - `fluent-bit/` – Fluent Bit configuration files.
 - `filebeat/` – Filebeat configuration files.

--- a/app.py
+++ b/app.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from flask import Flask, request, jsonify, make_response
+import os
 from flask_cors import CORS
 
 from trinity_ai import TrinityAI
 
-PINARCH_TOKEN = "DSFSfdss22$24@21--sdfsfsdf2442442"
+PINARCH_TOKEN = os.getenv("PINARCH_TOKEN")
+if not PINARCH_TOKEN:
+    raise RuntimeError("PINARCH_TOKEN environment variable not set")
 
 app = Flask(__name__)
 CORS(app)

--- a/scripts/deploy_filebeat.py
+++ b/scripts/deploy_filebeat.py
@@ -6,7 +6,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 SSH_USER = os.getenv("SSH_USER", "root")
-SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
+SSH_PASSWORD = os.getenv("SSH_PASSWORD")
+if not SSH_PASSWORD:
+    raise RuntimeError("SSH_PASSWORD environment variable not set")
 FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_filebeat.yml"
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"
 

--- a/scripts/e2e_test.py
+++ b/scripts/e2e_test.py
@@ -7,7 +7,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 SSH_USER = os.getenv("SSH_USER", "root")
-SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
+SSH_PASSWORD = os.getenv("SSH_PASSWORD")
+if not SSH_PASSWORD:
+    raise RuntimeError("SSH_PASSWORD environment variable not set")
 
 NODES = [
     "145.223.73.4",

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from pathlib import Path
 
 SSH_USER = os.getenv("SSH_USER", "root")
-SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
+SSH_PASSWORD = os.getenv("SSH_PASSWORD")
+if not SSH_PASSWORD:
+    raise RuntimeError("SSH_PASSWORD environment variable not set")
 
 NODES = [
     "31.97.13.92",

--- a/scripts/recover_and_deploy.py
+++ b/scripts/recover_and_deploy.py
@@ -7,7 +7,9 @@ from datetime import datetime
 from pathlib import Path
 
 SSH_USER = os.getenv("SSH_USER", "root")
-SSH_PASSWORD = os.getenv("SSH_PASSWORD", "SDAasdsa23..dsS")
+SSH_PASSWORD = os.getenv("SSH_PASSWORD")
+if not SSH_PASSWORD:
+    raise RuntimeError("SSH_PASSWORD environment variable not set")
 
 NODES = [
     "31.97.13.92",

--- a/scripts/vps_tunnel_setup.sh
+++ b/scripts/vps_tunnel_setup.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 RUNPOD_HOST="root@d82c6a1a4730"
 RUNPOD_PORT=22
-SSH_PASSWORD="SDAasdsa23..dsS"
+SSH_PASSWORD="${SSH_PASSWORD:?SSH_PASSWORD environment variable not set}"
 LOCAL_PORT=5044
 
 usage() {


### PR DESCRIPTION
## Summary
- read `PINARCH_TOKEN` from environment in `app.py`
- require `SSH_PASSWORD` environment variable for deployment scripts
- require `SSH_PASSWORD` environment variable in tunnel helper
- document the required environment variables

## Testing
- `scripts/run_tests.sh`
- `python3 -m py_compile app.py scripts/deploy_filebeat.py scripts/recover_and_deploy.py scripts/monitor.py scripts/e2e_test.py`