### PR TITLE
Add Nginx SSL recovery script

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ sudo scripts/enable_external_access.sh
 
 This script enables ports 80 and 443 via `ufw` and `iptables`, ensures Nginx listens on all interfaces, and reloads the server.
 
+## Fixing Missing SSL Configuration
+
+If Nginx fails to start because the LetsEncrypt files referenced in
+`/etc/nginx/sites-available/trinity-final.conf` are absent, run:
+
+```bash
+sudo scripts/fix_nginx_ssl.sh
+```
+
+The script backs up the configuration, comments out the missing include
+lines and any SSL directives if the certificate is absent, tests the configuration and reloads Nginx.
+
 ## Trinity AI Web Interface
 
 A minimal web interface is provided as a starting point for the future

--- a/scripts/fix_nginx_ssl.sh
+++ b/scripts/fix_nginx_ssl.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# fix_nginx_ssl.sh - Disable missing LetsEncrypt includes and SSL directives
+
+set -euo pipefail
+
+CONFIG_FILE="/etc/nginx/sites-available/trinity-final.conf"
+CERT_DIR="/etc/letsencrypt/live/325automations.com"
+TIMESTAMP="$(date '+%Y%m%d_%H%M%S')"
+BACKUP_FILE="${CONFIG_FILE}.backup_${TIMESTAMP}"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Please run this script with sudo or as root." >&2
+  exit 1
+fi
+
+log "Backing up ${CONFIG_FILE} to ${BACKUP_FILE}"
+cp "$CONFIG_FILE" "$BACKUP_FILE"
+
+log "Commenting out missing SSL include lines"
+sed -i \
+  -e 's@^\( *\)include /etc/letsencrypt/options-ssl-nginx.conf;@#&@' \
+  -e 's@^\( *\)ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;@#&@' \
+  "$CONFIG_FILE"
+
+if [ ! -f "${CERT_DIR}/fullchain.pem" ] || [ ! -f "${CERT_DIR}/privkey.pem" ]; then
+  log "Certificate files not found; disabling SSL directives"
+  sed -i \
+    -e 's@^\( *\)ssl_certificate .*;@#&@' \
+    -e 's@^\( *\)ssl_certificate_key .*;@#&@' \
+    -e 's@^\( *\)listen \([^ ]*\) ssl;@#&@' \
+    "$CONFIG_FILE"
+fi
+
+log "Testing new Nginx configuration"
+if nginx -t; then
+  log "Configuration test succeeded. Reloading Nginx"
+  if nginx -s reload 2>/dev/null; then
+    log "Nginx reloaded successfully"
+  else
+    log "Reload failed. Trying 'service nginx restart'"
+    if service nginx restart; then
+      log "Nginx restarted successfully"
+    else
+      log "Failed to restart Nginx. Please investigate further"
+      exit 1
+    fi
+  fi
+  log "Check Nginx: sudo ss -tlnp | grep nginx"
+else
+  log "Configuration test failed! Restore the backup with:"
+  log "sudo cp \"$BACKUP_FILE\" \"$CONFIG_FILE\""
+  exit 1
+fi
+
+log "Script completed"


### PR DESCRIPTION
## Summary
- add `fix_nginx_ssl.sh` helper to disable missing SSL directives and reload Nginx
- document the new script in the README

## Testing
- `scripts/run_tests.sh`