### PR TITLE
Add domain option to SSL fix script

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ If Nginx fails to start because the LetsEncrypt files referenced in
 `/etc/nginx/sites-available/trinity-final.conf` are absent, run:
 
 ```bash
-sudo scripts/fix_nginx_ssl.sh
+sudo scripts/fix_nginx_ssl.sh [domain]
 ```
 
-The script backs up the configuration, comments out the missing include
+Pass the domain as an argument or via the `DOMAIN` environment variable to control which
+certificate directory under `/etc/letsencrypt/live` is checked. If omitted, it defaults to
+`325automations.com`. The script backs up the configuration, comments out the missing include
 lines and any SSL directives if the certificate is absent, tests the configuration and reloads Nginx.
 
 ## Trinity AI Web Interface

--- a/scripts/fix_nginx_ssl.sh
+++ b/scripts/fix_nginx_ssl.sh
@@ -3,8 +3,23 @@
 
 set -euo pipefail
 
+usage() {
+  echo "Usage: $0 [DOMAIN]" >&2
+  echo "Disable SSL directives when LetsEncrypt files are missing." >&2
+  echo "DOMAIN specifies the certificate directory under /etc/letsencrypt/live." >&2
+  echo "It can also be provided via the DOMAIN environment variable." >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
 CONFIG_FILE="/etc/nginx/sites-available/trinity-final.conf"
-CERT_DIR="/etc/letsencrypt/live/325automations.com"
+# Domain used to locate LetsEncrypt certificates. Can be overridden via the
+# DOMAIN environment variable or passed as the first argument.
+DOMAIN="${1:-${DOMAIN:-325automations.com}}"
+CERT_DIR="/etc/letsencrypt/live/${DOMAIN}"
 TIMESTAMP="$(date '+%Y%m%d_%H%M%S')"
 BACKUP_FILE="${CONFIG_FILE}.backup_${TIMESTAMP}"
 


### PR DESCRIPTION
## Summary
- allow overriding the Let's Encrypt domain used by `scripts/fix_nginx_ssl.sh`
- document the new optional parameter in both the script help and README

## Testing
- `scripts/run_tests.sh`