### PR TITLE
Update Trinity for /james deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,11 @@ A minimal web interface is provided as a starting point for the future
 
 The frontend will send chat prompts to `http://localhost:5001/api/chat` and
 display the result.
+
+### Hosting under `/james`
+
+The included Nginx configurations and Next.js project are prepared to host the
+Trinity UI at `https://325automations.com/james`. When deploying to a server,
+copy one of the provided site configs to `/etc/nginx/sites-available`, enable it
+and reload Nginx. Requests to `/james` will be proxied to the Next.js frontend
+and `/james/api/` will reach the Flask backend.

--- a/etc/nginx/sites-available/trinity-complete
+++ b/etc/nginx/sites-available/trinity-complete
@@ -10,18 +10,21 @@ server {
     ssl_certificate     /etc/ssl/certs/placeholder.crt;
     ssl_certificate_key /etc/ssl/private/placeholder.key;
 
+    # Redirect the root to the James interface hosted under /james
     location = / {
-        return 302 https://325automations.com/login;
+        return 302 https://325automations.com/james/login;
     }
 
-    location / {
-        proxy_pass http://${UI_HOST}:${UI_PORT};
+    # Serve the Next.js UI from /james
+    location /james/ {
+        proxy_pass http://${UI_HOST}:${UI_PORT}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    location /api/ {
-        proxy_pass http://${API_HOST}:${API_PORT};
+    # Proxy API requests also under the /james prefix
+    location /james/api/ {
+        proxy_pass http://${API_HOST}:${API_PORT}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/etc/nginx/sites-available/trinity-nuclear
+++ b/etc/nginx/sites-available/trinity-nuclear
@@ -9,12 +9,14 @@ server {
     ssl_certificate     /etc/ssl/certs/placeholder.crt;
     ssl_certificate_key /etc/ssl/private/placeholder.key;
 
+    # Redirect the root to the James interface hosted under /james
     location = / {
-        return 302 https://325automations.com/login;
+        return 302 https://325automations.com/james/login;
     }
 
-    location / {
-        proxy_pass http://${UI_HOST}:${UI_PORT};
+    # Serve the Next.js UI from /james
+    location /james/ {
+        proxy_pass http://${UI_HOST}:${UI_PORT}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
@@ -22,8 +24,9 @@ server {
         proxy_set_header Connection 'upgrade';
     }
 
-    location /api/ {
-        proxy_pass http://${API_HOST}:${API_PORT};
+    # Proxy API requests also under the /james prefix
+    location /james/api/ {
+        proxy_pass http://${API_HOST}:${API_PORT}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/var/www/html/james/ultimate_ui/.env.local
+++ b/var/www/html/james/ultimate_ui/.env.local
@@ -1,3 +1,3 @@
 PORT=3000
-NEXT_PUBLIC_API_URL=https://325automations.com/api
+NEXT_PUBLIC_API_URL=https://325automations.com/james/api
 

--- a/var/www/html/james/ultimate_ui/next.config.js
+++ b/var/www/html/james/ultimate_ui/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Serve the UI under the `/james` base path so it can be hosted at
+  // https://325automations.com/james.
+  basePath: '/james',
   // The `app` directory is stable in Next.js 14 so no experimental flag is
   // required. Removing `experimental.appDir` avoids a config validation error
   // during `next build`.


### PR DESCRIPTION
## Summary
- host Trinity UI under `/james`
- add Nginx rules to proxy `/james` paths
- document how to host at `https://325automations.com/james`

## Testing
- `scripts/run_tests.sh`