### PR TITLE
Add /james proxy route to nginx configs

### DIFF
--- a/etc/nginx/sites-available/trinity-complete
+++ b/etc/nginx/sites-available/trinity-complete
@@ -20,6 +20,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /james {
+        proxy_pass http://${UI_HOST}:${UI_PORT};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location /api/ {
         proxy_pass http://${API_HOST}:${API_PORT};
         proxy_set_header Host $host;

--- a/etc/nginx/sites-available/trinity-nuclear
+++ b/etc/nginx/sites-available/trinity-nuclear
@@ -22,6 +22,15 @@ server {
         proxy_set_header Connection 'upgrade';
     }
 
+    location /james {
+        proxy_pass http://${UI_HOST}:${UI_PORT};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+    }
+
     location /api/ {
         proxy_pass http://${API_HOST}:${API_PORT};
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- expose /james path via nginx
- support websocket upgrades in trinity-nuclear

## Testing
- `scripts/run_tests.sh`