### PR TITLE
Clarify OpenEvolve backend status

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ port `5044` into the SSH tunnel.
 - **Gemini** via an OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`).
 - **OpenEvolve** for GitHub workflow automation.
 
+The OpenEvolve integration currently only dispatches a placeholder GitHub
+workflow. The real backend service is still under development and is not yet
+available.
+
 Example usage:
 
 ```bash

--- a/trinity_ai.py
+++ b/trinity_ai.py
@@ -1,4 +1,9 @@
-"""Unified interface for ChatGPT, Gemini, and OpenEvolve."""
+"""Unified interface for ChatGPT, Gemini, and OpenEvolve.
+
+TODO: integrate with the actual OpenEvolve backend once it becomes
+available. Currently the OpenEvolve support merely dispatches a placeholder
+GitHub workflow.
+"""
 
 from __future__ import annotations
 
@@ -46,7 +51,11 @@ class TrinityAI:
         raise ValueError(f"Unknown model: {model}")
 
     def _open_evolve_action(self, instruction: str) -> str:
-        """Trigger an OpenEvolve GitHub workflow."""
+        """Trigger an OpenEvolve GitHub workflow.
+
+        TODO: replace this placeholder implementation with calls to the
+        official OpenEvolve API once it is released.
+        """
 
         if not self.open_evolve_token:
             raise RuntimeError("OPENEVOLVE_TOKEN environment variable not set")


### PR DESCRIPTION
## Summary
- note that OpenEvolve is not implemented yet in the README
- add TODOs in `trinity_ai.py` for upcoming OpenEvolve backend

## Testing
- `scripts/run_tests.sh`