### PR TITLE
Remove real IP addresses and load from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ var/www/html/james/ultimate_ui/.next/
 .env
 var/www/html/james/ultimate_ui/.next/
 *.log
+
+etc/addresses.env

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ scripts/start_trinity_frontend.sh
 - `fluent-bit/` – Fluent Bit configuration files.
 - `filebeat/` – Filebeat configuration files.
 - `scripts/` – Automation scripts for deployment, rollback, health checks, testing and Filebeat setup.
-- `etc/addresses.env` – Example environment file providing IP addresses for all scripts.
+- `etc/addresses.env.example` – Template environment file providing IP addresses for all scripts.
 
 ## Usage
 
@@ -77,9 +77,10 @@ scripts/e2e_test.py
 ## Configuring IP addresses
 
 All deployment and monitoring scripts read the list of VPS nodes and the
-address of the core aggregator from environment variables. An example
-file `etc/addresses.env` is provided. Source this file (or define the
-variables manually) before running any script:
+address of the core aggregator from environment variables. A template
+file `etc/addresses.env.example` is provided. Copy this file to
+`etc/addresses.env` and replace the placeholders (or define the variables
+manually) before running any script:
 
 ```bash
 source etc/addresses.env

--- a/etc/addresses.env
+++ b/etc/addresses.env
@@ -1,6 +1,0 @@
-# Default IP addresses for deployment scripts
-# NODES is a comma-separated list of VPS hosts
-# CORE_VPS is the address of the central log aggregator
-# Updated to include all six VPS nodes
-NODES="31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106"
-CORE_VPS="145.223.73.4"

--- a/etc/addresses.env.example
+++ b/etc/addresses.env.example
@@ -1,0 +1,9 @@
+# Example IP addresses for deployment scripts
+# Copy this file to etc/addresses.env and replace the values
+# with your real environment details. Keep this file out of version control.
+
+# Comma-separated list of node IP addresses
+NODES="192.0.2.10,192.0.2.11,192.0.2.12"
+
+# IP address of the central log aggregator
+CORE_VPS="198.51.100.5"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,8 +7,10 @@ if [ -f "$CONFIG_FILE" ]; then
   source "$CONFIG_FILE"
 fi
 
-: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106}"
-: "${CORE_VPS:=145.223.73.4}"
+if [ -z "${NODES:-}" ] || [ -z "${CORE_VPS:-}" ]; then
+  echo "NODES and CORE_VPS must be set via environment or $CONFIG_FILE" >&2
+  exit 1
+fi
 IFS=',' read -r -a NODES <<< "$NODES"
 CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/fluent-bit"
 BACKUP_DIR=/var/backups/fluent-bit

--- a/scripts/deploy_filebeat.py
+++ b/scripts/deploy_filebeat.py
@@ -12,11 +12,29 @@ if not SSH_PASSWORD:
 FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_filebeat.yml"
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"
 
-NODES = os.getenv(
-    "NODES",
-    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106",
-).split(",")
-CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
+def load_addresses() -> None:
+    if os.getenv("NODES") and os.getenv("CORE_VPS"):
+        return
+    env_file = Path(__file__).resolve().parents[1] / "etc" / "addresses.env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("NODES=") and not os.getenv("NODES"):
+                    os.environ["NODES"] = line.split("=", 1)[1].strip().strip('"')
+                elif line.startswith("CORE_VPS=") and not os.getenv("CORE_VPS"):
+                    os.environ["CORE_VPS"] = line.split("=", 1)[1].strip().strip('"')
+
+
+load_addresses()
+
+nodes_env = os.getenv("NODES")
+core_vps = os.getenv("CORE_VPS")
+if not nodes_env or not core_vps:
+    raise RuntimeError("NODES and CORE_VPS must be set via environment or addresses.env")
+
+NODES = nodes_env.split(",")
+CORE_VPS = core_vps
 
 
 def log(msg: str):

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -7,8 +7,10 @@ if [ -f "$CONFIG_FILE" ]; then
   source "$CONFIG_FILE"
 fi
 
-: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106}"
-: "${CORE_VPS:=145.223.73.4}"
+if [ -z "${NODES:-}" ] || [ -z "${CORE_VPS:-}" ]; then
+  echo "NODES and CORE_VPS must be set via environment or $CONFIG_FILE" >&2
+  exit 1
+fi
 IFS=',' read -r -a NODES <<< "$NODES"
 PORT=5044
 

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -10,11 +10,29 @@ SSH_PASSWORD = os.getenv("SSH_PASSWORD")
 if not SSH_PASSWORD:
     raise RuntimeError("SSH_PASSWORD environment variable not set")
 
-NODES = os.getenv(
-    "NODES",
-    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106",
-).split(",")
-CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
+def load_addresses() -> None:
+    if os.getenv("NODES") and os.getenv("CORE_VPS"):
+        return
+    env_file = Path(__file__).resolve().parents[1] / "etc" / "addresses.env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("NODES=") and not os.getenv("NODES"):
+                    os.environ["NODES"] = line.split("=", 1)[1].strip().strip('"')
+                elif line.startswith("CORE_VPS=") and not os.getenv("CORE_VPS"):
+                    os.environ["CORE_VPS"] = line.split("=", 1)[1].strip().strip('"')
+
+
+load_addresses()
+
+nodes_env = os.getenv("NODES")
+core_vps = os.getenv("CORE_VPS")
+if not nodes_env or not core_vps:
+    raise RuntimeError("NODES and CORE_VPS must be set via environment or addresses.env")
+
+NODES = nodes_env.split(",")
+CORE_VPS = core_vps
 LOG_PATH = "/tmp/vps_combined.log"
 THRESHOLD = 5_000_000  # rotate log above 5MB
 

--- a/scripts/recover_and_deploy.py
+++ b/scripts/recover_and_deploy.py
@@ -11,11 +11,29 @@ SSH_PASSWORD = os.getenv("SSH_PASSWORD")
 if not SSH_PASSWORD:
     raise RuntimeError("SSH_PASSWORD environment variable not set")
 
-NODES = os.getenv(
-    "NODES",
-    "31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106",
-).split(",")
-CORE_VPS = os.getenv("CORE_VPS", "145.223.73.4")
+def load_addresses() -> None:
+    if os.getenv("NODES") and os.getenv("CORE_VPS"):
+        return
+    env_file = Path(__file__).resolve().parents[1] / "etc" / "addresses.env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("NODES=") and not os.getenv("NODES"):
+                    os.environ["NODES"] = line.split("=", 1)[1].strip().strip('"')
+                elif line.startswith("CORE_VPS=") and not os.getenv("CORE_VPS"):
+                    os.environ["CORE_VPS"] = line.split("=", 1)[1].strip().strip('"')
+
+
+load_addresses()
+
+nodes_env = os.getenv("NODES")
+core_vps = os.getenv("CORE_VPS")
+if not nodes_env or not core_vps:
+    raise RuntimeError("NODES and CORE_VPS must be set via environment or addresses.env")
+
+NODES = nodes_env.split(",")
+CORE_VPS = core_vps
 
 FILEBEAT_CONFIG = Path(__file__).resolve().parents[1] / "filebeat" / "corrected_filebeat.yml"
 FLUENT_BIT_CONFIG = Path(__file__).resolve().parents[1] / "fluent-bit" / "fluent-bit.conf"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -7,8 +7,10 @@ if [ -f "$CONFIG_FILE" ]; then
   source "$CONFIG_FILE"
 fi
 
-: "${NODES:=31.97.13.92,31.97.13.95,31.97.13.100,31.97.13.102,31.97.13.104,31.97.13.106}"
-: "${CORE_VPS:=145.223.73.4}"
+if [ -z "${NODES:-}" ] || [ -z "${CORE_VPS:-}" ]; then
+  echo "NODES and CORE_VPS must be set via environment or $CONFIG_FILE" >&2
+  exit 1
+fi
 IFS=',' read -r -a NODES <<< "$NODES"
 BACKUP_DIR=/var/backups/fluent-bit
 

--- a/scripts/vps_tunnel_setup.sh
+++ b/scripts/vps_tunnel_setup.sh
@@ -2,14 +2,14 @@
 # vps_tunnel_setup.sh - Create a persistent SSH tunnel from a VPS node to RunPod
 #
 # Usage: vps_tunnel_setup.sh <remote_port>
-# Each VPS is assigned a unique remote_port:
-#   145.223.73.4 -> 5045
-#   31.97.13.92  -> 5046
-#   31.97.13.95  -> 5047
-#   31.97.13.100 -> 5048
-#   31.97.13.102 -> 5049
-#   31.97.13.104 -> 5050
-#   31.97.13.106 -> 5051
+# Each VPS is assigned a unique remote_port. Example mapping:
+#   198.51.100.5 -> 5045
+#   192.0.2.10   -> 5046
+#   192.0.2.11   -> 5047
+#   192.0.2.12   -> 5048
+#   192.0.2.13   -> 5049
+#   192.0.2.14   -> 5050
+#   192.0.2.15   -> 5051
 #
 # The script configures autossh to expose local Filebeat (localhost:5044)
 # to RunPod on the given remote port. autossh automatically restarts the


### PR DESCRIPTION
## Summary
- ignore `etc/addresses.env`
- add `etc/addresses.env.example` with placeholder addresses
- update README to explain copying template
- update scripts to read `NODES` and `CORE_VPS` from environment or `addresses.env`
- replace real IPs in `vps_tunnel_setup.sh`

## Testing
- `scripts/run_tests.sh`