### PR TITLE
Enable frontend to use API_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,11 @@ available from the `/james` path on your domain.
    npm run dev
    ```
 
-4. To build and serve the UI in production, execute:
+4. Create or edit the `.env.local` file in that directory and set
+   `NEXT_PUBLIC_API_URL` to the base URL of the backend, e.g.
+   `http://localhost:5001`.
+
+5. To build and serve the UI in production, execute:
    ```bash
    NODE_OPTIONS=--max-old-space-size=4096 npm run build
    npm run start

--- a/var/www/html/james/ultimate_ui/.env.local
+++ b/var/www/html/james/ultimate_ui/.env.local
@@ -1,3 +1,3 @@
 PORT=3000
-NEXT_PUBLIC_API_URL=https://325automations.com/api
+NEXT_PUBLIC_API_URL=http://localhost:5001
 

--- a/var/www/html/james/ultimate_ui/README.md
+++ b/var/www/html/james/ultimate_ui/README.md
@@ -16,6 +16,8 @@ It provides a basic chat interface that communicates with the Flask backend in
    ```
 
 The app expects the Flask API to be running on `http://localhost:5001`.
+Set `NEXT_PUBLIC_API_URL` in `.env.local` to point to this base URL so that
+`fetch` calls reach the correct backend during development.
 
 This project is configured with `basePath: '/james'` so assets are served under
 that URL segment. Update `next.config.js` if deploying elsewhere.

--- a/var/www/html/james/ultimate_ui/app/dashboard/page.tsx
+++ b/var/www/html/james/ultimate_ui/app/dashboard/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 import { useEffect, useState } from 'react';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
 export default function Dashboard() {
   const [stats, setStats] = useState<any>(null);
 
   useEffect(() => {
-    fetch('/api/stats')
+    fetch(`${API_URL}/api/stats`)
       .then((res) => res.json())
       .then(setStats)
       .catch(() => setStats(null));

--- a/var/www/html/james/ultimate_ui/app/login/page.tsx
+++ b/var/www/html/james/ultimate_ui/app/login/page.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
 export default function Login() {
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
@@ -9,7 +11,7 @@ export default function Login() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch('/api/login', {
+    const res = await fetch(`${API_URL}/api/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ token }),


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` in login and dashboard pages
- document `.env.local` API base URL
- note the env var in frontend README
- update default `.env.local`

## Testing
- `scripts/run_tests.sh`