### PR TITLE
Redirect to /james/login in nginx configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ A minimal web interface is provided as a starting point for the future
 "ultimate" Trinity AI UI. The backend API is implemented with Flask in
 `app.py` and exposes a `/api/chat` endpoint. The production Next.js 14 frontend
 resides in `var/www/html/james/ultimate_ui/`. When served behind Nginx it is
-available from the `/james` path on your domain.
+available from the `/james` path on your domain. The domain root is configured
+to redirect to `/james/login`.
 
 ### Running locally
 

--- a/etc/nginx/sites-available/trinity-complete
+++ b/etc/nginx/sites-available/trinity-complete
@@ -11,7 +11,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/325automations.com/privkey.pem;
 
     location = / {
-        return 302 https://325automations.com/login;
+        return 302 https://325automations.com/james/login;
     }
 
     location / {

--- a/etc/nginx/sites-available/trinity-nuclear
+++ b/etc/nginx/sites-available/trinity-nuclear
@@ -10,7 +10,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/325automations.com/privkey.pem;
 
     location = / {
-        return 302 https://325automations.com/login;
+        return 302 https://325automations.com/james/login;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- update nginx configs to redirect / to /james/login
- document new root redirect in README

## Testing
- `PYTHONPATH=. pytest -q`